### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,6 @@ To add a resource or contribute, please check out our contribution guide [here](
 ## Linux
 
 - [Introduction to Linux](https://training.linuxfoundation.org/resources/free-courses/introduction-to-linux/)
-- [Introduction to the world of ricing](https://zoug.top/posts/introduction-to-ricing/)
 - [The Linux guide/cheatsheet/tutorial (Commands, Directories, etc)](https://dev.to/kedark/the-linux-guide-cheatsheet-commands-directories-etc-39k0)
 - [Linux kernel and its insides](https://0xax.gitbooks.io/linux-insides/content/)
 - [Interactive map of Linux Kernel](https://makelinux.github.io/kernel/map/)

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ To add a resource or contribute, please check out our contribution guide [here](
 ## Linux
 
 - [Introduction to Linux](https://training.linuxfoundation.org/resources/free-courses/introduction-to-linux/)
-- [Introduction to the world of ricing](https://zoug.top/2016/12/26/introduction-to-ricing/)
+- [Introduction to the world of ricing](https://zoug.top/posts/introduction-to-ricing/)
 - [The Linux guide/cheatsheet/tutorial (Commands, Directories, etc)](https://dev.to/kedark/the-linux-guide-cheatsheet-commands-directories-etc-39k0)
 - [Linux kernel and its insides](https://0xax.gitbooks.io/linux-insides/content/)
 - [Interactive map of Linux Kernel](https://makelinux.github.io/kernel/map/)


### PR DESCRIPTION
I was checking the sections here and found a broken link

Introduction to the world of ricing was pointing to https://zoug.top/2016/12/26/introduction-to-ricing/  which goes to a 404 but seems it changed site layout and the content is now in https://zoug.top/posts/introduction-to-ricing/

Note that currently it gives for some systems a security alert "Certificate Expired" this is because the site uses a chain from let's encrypt that has recently had an issue with his chain of trust, see https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/ but the site is perfectly safe.