### PR TITLE
Remove Open Source Love image to fix issue #435

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guide
 
-[![Open Source Love](https://firstcontributions.github.io/open-source-badges/badges/open-source-v1/open-source.svg)](https://github.com/firstcontributions/open-source-badges)  [![Pull Requests Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat)](http://makeapullrequest.com)
+[![Pull Requests Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat)](http://makeapullrequest.com)
 
 ## Content
 


### PR DESCRIPTION
I've removed the open source love image to fix issue #435. However, issue #435 states to remove the image because it is broken. The image **was not** broken when I went to fix this issue. Previously, the image did not load correctly, but I can see it now. 