### PR TITLE
Add fly.io to "free hosting" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ Throughout this list you'll see next to each resource and emoji. Here's what eac
 - :wrench: [Netlify](https://www.netlify.com/)
 - :wrench: [Heroku](https://www.heroku.com/)
 - :wrench: [Vercel](https://vercel.com/)
+- :wrench: [Fly.io](https://fly.io/)
 - :wrench: [Github Pages](http://pages.github.com)
 - :wrench: [Gitlab Pages](http://docs.gitlab.com/ee/user/project/pages)
 - :wrench: [Deta](https://www.deta.sh/)


### PR DESCRIPTION
Hi!
I added [Fly.io](https://fly.io/) to the "free hosting" section.
They offer free servers according to https://fly.io/docs/about/pricing/

![screenshot](https://user-images.githubusercontent.com/18481195/193405736-5feb0aca-b34e-49d2-bb7d-887f989c7806.png)
