### PR TITLE
Add Laravel Bootcamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,7 @@ Throughout this list you'll see next to each resource and emoji. Here's what eac
 - :books: [Laravel News](https://laravel-news.com)
 - :books: [LaraShout: Laravel Tutorials and Guides](https://www.larashout.com)
 - :bulb: [Laravel Daily](https://laraveldaily.com)
+- :books: [Laravel Bootcamp](https://bootcamp.laravel.com)
 
 ---
 


### PR DESCRIPTION
[Laravel Bootcamp](https://bootcamp.laravel.com) is official guide from Laravel team to help developers that are new to the framework get up and going quickly.