### PR TITLE
Added CodePath Cliffnotes under Android Category.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Throughout this list you'll see next to each resource and emoji. Here's what eac
 - :bulb: [Awesome Android](https://github.com/JStumpp/awesome-android)
 - :books: [Kotlin Fundamentals for Android Developers](https://www.udacity.com/course/kotlin-bootcamp-for-programmers--ud9011)
 - :video_camera: [Android Jetpack Compose For Beginners](https://www.youtube.com/playlist?list=PLQkwcJG4YTCSpJ2NLhDTHhi6XBNfk9WiC)
+- 📚: [CodePath Cliffnotes](https://guides.codepath.com/android/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Throughout this list you'll see next to each resource and emoji. Here's what eac
 - :bulb: [Awesome Android](https://github.com/JStumpp/awesome-android)
 - :books: [Kotlin Fundamentals for Android Developers](https://www.udacity.com/course/kotlin-bootcamp-for-programmers--ud9011)
 - :video_camera: [Android Jetpack Compose For Beginners](https://www.youtube.com/playlist?list=PLQkwcJG4YTCSpJ2NLhDTHhi6XBNfk9WiC)
-- 📚: [CodePath Cliffnotes](https://guides.codepath.com/android/)
+- :books: [CodePath Cliffnotes](https://guides.codepath.com/android/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Throughout this list you'll see next to each resource and emoji. Here's what eac
 - :books: [Kotlin Fundamentals for Android Developers](https://www.udacity.com/course/kotlin-bootcamp-for-programmers--ud9011)
 - :video_camera: [Android Jetpack Compose For Beginners](https://www.youtube.com/playlist?list=PLQkwcJG4YTCSpJ2NLhDTHhi6XBNfk9WiC)
 - :books: [CodePath Cliffnotes](https://guides.codepath.com/android/)
+- :bulb: [Nisrulz Android Tips & Tricks](https://nisrulz.com/android-tips-tricks/)
 
 ---
 


### PR DESCRIPTION
Android CodePath Cliffnotes are a great long-tutorial resource curated by various organizations and individuals for quick-to-point reference.
Comprehensive Tutorials with all round coverage.