### PR TITLE
Fix markdown parsing error on website

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ Throughout this list you'll see next to each resource and emoji. Here's what eac
 - :video_camera: [Everything about using Celery with Django](https://youtube.com/playlist?list=PLLz6Bi1mIXhHKA1Szy2aj9Jbs6nw9fhNY)
 - :video_camera: [Python Backend Web Development Course (with Django)](https://youtu.be/jBzwzrDvZ18)
 - :video_camera: [Django tutorial for beginners](https://www.youtube.com/playlist?list=PLsyeobzWxl7r2ukVgTqIQcl-1T0C2mzau)
-- :video_camera: [Django Rest Framework Full Crash Course | Build REST APIs With Django](https://www.youtube.com/watch?v=wv8b3tzShq4)
+- :video_camera: [Django Rest Framework Full Crash Course - Build REST APIs With Django](https://www.youtube.com/watch?v=wv8b3tzShq4)
 - :bulb: [Django Cheatsheet](https://www.codewithharry.com/blogpost/django-cheatsheet)
 - :green_book: [Django REST APIs](https://djangostars.com/blog/rest-apis-django-development/)
 


### PR DESCRIPTION
There was a small Markdown parsing issue on the website, which caused one entry in the list to be rendered as a table, this PR should fix this:
![screenshot](https://github.com/shahednasser/awesome-resources/assets/18481195/67d2a994-b8ae-4665-ac66-14491ce7c665)
