### PR TITLE
added github workflow duplicates.yml for checking duplicate links and raising the issue if found any duplicate links

### DIFF
--- a/.github/workflows/duplicates.yml
+++ b/.github/workflows/duplicates.yml
@@ -1,0 +1,43 @@
+name: Check for Duplicate Links
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Runs every Sunday at midnight (UTC)
+
+jobs:
+  check_duplicates:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+  
+      - name: Check for duplicate Links
+        id: check_links
+        run: |
+          # Find all markdown files and extract links
+          links=$(grep -oh 'http[s]*://[^ ]*' **/*.md | sort | uniq -d)
+          
+          if [ -n "$links" ]; then
+            echo "::set-output name=duplicates::$links"
+          else
+            echo "No duplicate links found."
+          fi
+
+      - name: Create GitHub Issue
+        if: ${{ steps.check_links.outputs.duplicates != '' }}
+        uses: peter-evans/create-issue@v2
+        with:
+          title: 'Duplicate Links Found'
+          body: |
+            The following duplicate links were found:
+            ```
+            ${{ steps.check_links.outputs.duplicates }}
+            ```
+          labels: 'duplicate links'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request addresses Issue #434 (Add GitHub Action to catch duplicate links). There was no workflow for checking duplicate links in .github/workflows.
**Added**
- .github/workflows/duplicates.yml

***What it does ?***
-This automates the process of identifying and reporting duplicate URLs in markdown files  within a repository (by creating an issue). The purpose of this action is to ensure that no redundant or duplicate external links exist, improving the quality and organization of documentation or resource lists.

Fixed this issue .