### PR TITLE
Fixed Broken Link to Big Data Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Throughout this list you'll see next to each resource and emoji. Here's what eac
 - [Angular](#angular)
 - [Artificial Intelligence](#artificial-intelligence)
 - [AWS](#aws)
-- [Big Data](#bigdata)
+- [Big Data](#big-data)
 - [Blockchain](#blockchain)
 - [Bots](#bots)
 - [C](#c)


### PR DESCRIPTION
I updated the README file to fix a broken link directing to the Big Data section. The issue was causing confusion for users trying to access relevant information. The link is now properly working, ensuring smooth navigation and an improved user experience.