### PR TITLE
Fix: Big Data  link not navigating to the correct section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Throughout this list you'll see next to each resource and emoji. Here's what eac
 - [Angular](#angular)
 - [Artificial Intelligence](#artificial-intelligence)
 - [AWS](#aws)
-- [Big Data](#bigdata)
+- [Big Data](#big-data)
 - [Blockchain](#blockchain)
 - [Bots](#bots)
 - [C](#c)


### PR DESCRIPTION
The anchor link for the Big Data section on the [Awesome Resources](https://shahednasser.github.io/awesome-resources/) site was not working correctly. When clicking on "Big Data" in the sidebar or from the homepage, it didn’t scroll to the correct section.

🔧 I made a small change in the README.md file to correct the anchor link.
Now, clicking on Big Data properly navigates to the intended section in the resources.